### PR TITLE
enemyRadius not set in setup

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -40,13 +40,13 @@ function setup() {
   for (var i = 0; i < coinNum; i++) {
     append(coinsX, random(-2000, 2000));
     append(coinsY, random(-2000, 2000));
-    append(coinColor, [random(255), random(255), random(255)])
-    
+    append(coinColor, [random(255), random(255), random(255)]);
   }
   for (var i = 0; i < enemyNum; i++) {
     append(enemyX, random(-2000, 2000));
     append(enemyY, random(-2000, 2000));
-    append(enemyColor, [random(255), random(255), random(255)])
+    append(enemyColor, [random(255), random(255), random(255)]);
+    append(enemyRadius, int(random(50, 150)));
   }
 }  
 


### PR DESCRIPTION
In the setup of the game, the enemyRadius list is not poppulated.

Only somewhere in the draw function it sometimes get set. (idk what the hell happens there).
But the enemyRadius list contained empty items.

In the new commit all the bots get a radius set in the setup.